### PR TITLE
Jiff 0.1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v0.0.25 [2024-01-07] (25 for 2025)
+
+- `jiff`
+  - Updated to `0.1.21` which has span and signed duration strings with capital letters
+
+
+___
+
 ## v0.0.24 [2024-12-24] (the night b4 xmas...)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,11 +815,14 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jiff"
-version = "0.1.16"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a46169c7a10358cdccfb179910e8a5a392fc291bdb409da9aeece5b19786d8"
+checksum = "ed0ce60560149333a8e41ca7dc78799c47c5fd435e2bc18faf6a054382eec037"
 dependencies = [
  "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
  "serde",
  "windows-sys 0.59.0",
 ]
@@ -1155,6 +1158,15 @@ name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "ry"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "jiff",
  "pyo3",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "jiff",
  "pyo3",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-brotli"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "brotli",
  "pyo3",
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-bytes"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "bytes",
  "pyo3",
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-bzip2"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "bzip2",
  "pyo3",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-dev"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "pyo3",
  "ryo3-reqwest",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-dirs"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "dirs",
  "pyo3",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-flate2"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "flate2",
  "pyo3",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-fnv"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "fnv",
  "pyo3",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-fspath"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "pyo3",
  "ryo3-dirs",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-globset"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "globset",
  "pyo3",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-heck"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "heck",
  "pyo3",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-http"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "http",
  "pyo3",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-jiff"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "jiff",
  "pyo3",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-jiter"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "jiter",
  "pyo3",
@@ -1776,21 +1776,21 @@ dependencies = [
 
 [[package]]
 name = "ryo3-macros"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "ryo3-quick-maths"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "ryo3-regex"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "pyo3",
  "regex",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-reqwest"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-shlex"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "pyo3",
  "shlex",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-sqlformat"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "pyo3",
  "sqlformat",
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-std"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "pyo3",
  "ryo3-macros",
@@ -1842,14 +1842,14 @@ dependencies = [
 
 [[package]]
 name = "ryo3-types"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "ryo3-unindent"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "pyo3",
  "unindent",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-url"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "pyo3",
  "url",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-walkdir"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "pyo3",
  "ryo3-globset",
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-which"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "pyo3",
  "ryo3-regex",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-xxhash"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "pyo3",
  "xxhash-rust",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-zstd"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "pyo3",
  "zstd",
@@ -1982,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ bytes = "1.9.0"
 dirs = { version = "5.0.1", features = [] }
 heck = "0.5.0"
 http = "1.2.0"
-jiff = "0.1.16"
+jiff = "0.1.21"
 jiter = { version = "0.8.2", features = ["python"] }
 pyo3 = { version = "0.23.3", features = ["experimental-inspect", "num-bigint"] }
 pyo3-async-runtimes = { version = "0.23", features = ["attributes", "tokio-runtime"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.24"
+version = "0.0.25"
 authors = [
   "Jesse K. Rubin <jessekrubin@gmail.com>",
   # hopefully you will contribute!
@@ -142,7 +142,7 @@ pyo3-build-config = "0.23.3"
 regex = "1.11.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.12"
-serde_json = "1.0.134"
+serde_json = "1.0.135"
 shlex = "1.3.0"
 thiserror = "2.0.9"
 tokio = { version = "1.41.1", features = ["full"] }

--- a/crates/ryo3-jiff/Cargo.toml
+++ b/crates/ryo3-jiff/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-jiff = { version = "0.1.16", features = ["default", "serde"] }
+jiff = { version = "0.1.21", features = ["default", "serde"] }
 ryo3-std = { workspace = true }
 pyo3 = { workspace = true, features = ["experimental-inspect"] }
 ryo3-macros.workspace = true

--- a/tests/jiff/test_jiff.py
+++ b/tests/jiff/test_jiff.py
@@ -203,12 +203,12 @@ class TestTimeSpan:
         zdt1 = ry.date(2020, 8, 26).at(6, 27, 0, 0).intz("America/New_York")
         zdt2 = ry.date(2023, 12, 31).at(18, 30, 0, 0).intz("America/New_York")
         span = zdt2 - zdt1
-        assert span.string() == "PT29341h3m"
+        assert span.string() == "PT29341H3M"
         span_negated = -span
-        assert span_negated.string() == "-PT29341h3m"
+        assert span_negated.string() == "-PT29341H3M"
 
         span_inverted = ~span
-        assert span_inverted.string() == "-PT29341h3m"
+        assert span_inverted.string() == "-PT29341H3M"
 
     def test_span_2_duration(self) -> None:
         zdt1 = ry.date(2020, 8, 26).at(6, 27, 0, 0).intz("America/New_York")
@@ -341,7 +341,7 @@ class TestDateTime:
 class TestTimespanFunction:
     def test_timespan_fn(self) -> None:
         ts = ry.timespan(weeks=1)
-        assert ts.string() == "P1w"
+        assert ts.string() == "P1W"
 
     def test_timespan_overflow(self) -> None:
         max_i64 = 9_223_372_036_854_775_807

--- a/tests/jiff/test_jiff_examples.py
+++ b/tests/jiff/test_jiff_examples.py
@@ -33,7 +33,7 @@ def test_find_duration_between_datetimes() -> None:
     zdt2 = ry.date(2023, 12, 31).at(18, 30, 0, 0).intz("America/New_York")
     span = zdt2 - zdt1
     assert isinstance(span, ry.TimeSpan)
-    assert str(span) == "PT29341h3m"
+    assert str(span) == "PT29341H3M"
 
 
 def test_add_duration_to_a_zoned_datetime() -> None:
@@ -54,7 +54,7 @@ def test_parsing_a_span() -> None:
     span: ry.TimeSpan = ry.TimeSpan.parse("P5y1w10dT5h59m")
     expected = ry.TimeSpan()._years(5)._weeks(1)._days(10)._hours(5)._minutes(59)
     assert span == expected
-    assert str(span) == "P5y1w10dT5h59m"
+    assert str(span) == "P5Y1W10DT5H59M"
 
 
 def test_using_strftime_and_strptime_for_formatting_and_parsing() -> None:

--- a/tests/jiff/test_operators.py
+++ b/tests/jiff/test_operators.py
@@ -7,7 +7,7 @@ def test_time_sub() -> None:
     t1 = ry.time(16, 30, 59, 0)
     t2 = ry.time(16, 30, 0, 0)
     span = t1 - t2
-    assert span.string() == "PT59s"
+    assert span.string() == "PT59S"
     assert isinstance(span, ry.TimeSpan)
 
     inplace_time = ry.time(16, 30, 59, 0)
@@ -25,7 +25,7 @@ def test_time_add() -> None:
     t1 = ry.time(16, 30, 59, 0)
     t2 = ry.time(16, 30, 0, 0)
     span = t1 - t2
-    assert span.string() == "PT59s"
+    assert span.string() == "PT59S"
     assert isinstance(span, ry.TimeSpan)
 
     inplace_span = ry.time(16, 30, 0, 0)
@@ -42,7 +42,7 @@ def test_datetime_sub() -> None:
     t1 = ry.datetime(2021, 1, 1, 16, 30, 59, 0)
     t2 = ry.datetime(2021, 1, 1, 16, 30, 0, 0)
     span = t1 - t2
-    assert span.string() == "PT59s"
+    assert span.string() == "PT59S"
     assert isinstance(span, ry.TimeSpan)
 
     inplace_dt = ry.datetime(2021, 1, 1, 16, 30, 59, 0)
@@ -56,7 +56,7 @@ def test_datetime_add() -> None:
     t1 = ry.datetime(2021, 1, 1, 16, 30, 59, 0)
     t2 = ry.datetime(2021, 1, 1, 16, 30, 0, 0)
     span = t1 - t2
-    assert span.string() == "PT59s"
+    assert span.string() == "PT59S"
     assert isinstance(span, ry.TimeSpan)
 
     inplace_dt = ry.datetime(2021, 1, 1, 16, 30, 0, 0)
@@ -73,7 +73,7 @@ def test_date_sub() -> None:
     t1 = ry.date(2021, 1, 1)
     t2 = ry.date(2021, 1, 2)
     span = t1 - t2
-    assert span.string() == "-P1d"
+    assert span.string() == "-P1D"
     assert isinstance(span, ry.TimeSpan)
 
     inplace_span = ry.date(2021, 1, 1)
@@ -90,7 +90,7 @@ def test_date_add() -> None:
     t1 = ry.date(2021, 1, 1)
     t2 = ry.date(2021, 1, 2)
     span = t2 - t1
-    assert span.string() == "P1d"
+    assert span.string() == "P1D"
     assert isinstance(span, ry.TimeSpan)
 
     inplace_span = ry.date(2021, 1, 1)
@@ -112,7 +112,7 @@ def test_timestamp_sub() -> None:
         second=1609459201,
     )
     span = t1 - t2
-    assert span.string() == "-PT1s"
+    assert span.string() == "-PT1S"
     assert isinstance(span, ry.TimeSpan)
 
     inplace_ts = ry.Timestamp(
@@ -137,7 +137,7 @@ def test_timestamp_add() -> None:
         second=1609459201,
     )
     span = t2 - t1
-    assert span.string() == "PT1s"
+    assert span.string() == "PT1S"
     assert isinstance(span, ry.TimeSpan)
 
     inplace_span = ry.Timestamp(
@@ -157,7 +157,7 @@ def test_zoned_sub() -> None:
     zdt1 = ry.date(2020, 8, 26).at(6, 27, 0, 0).intz("America/New_York")
     zdt2 = ry.date(2020, 8, 26).at(6, 27, 0, 0).intz("America/Los_Angeles")
     span = zdt1 - zdt2
-    assert span.string() == "-PT3h"
+    assert span.string() == "-PT3H"
     assert isinstance(span, ry.TimeSpan)
 
     inplace_zdt = ry.date(2020, 8, 26).at(6, 27, 0, 0).intz("America/New_York")
@@ -174,7 +174,7 @@ def test_zoned_add() -> None:
     zdt1 = ry.date(2020, 8, 26).at(6, 27, 0, 0).intz("America/New_York")
     zdt2 = ry.date(2020, 8, 26).at(6, 27, 0, 0).intz("America/Los_Angeles")
     span = zdt1 - zdt2
-    assert span.string() == "-PT3h"
+    assert span.string() == "-PT3H"
     assert isinstance(span, ry.TimeSpan)
 
     inplace_zdt = ry.date(2020, 8, 26).at(6, 27, 0, 0).intz("America/Los_Angeles")

--- a/tests/jiff/test_time.py
+++ b/tests/jiff/test_time.py
@@ -33,7 +33,7 @@ def test_time_until() -> None:
     t1 = ry.time(3, 24, 30, 3500)
     t2 = ry.time(15, 30, 0, 0)
     span = t1.until(t2)
-    assert span.string() == "PT12h5m29.9999965s"
+    assert span.string() == "PT12H5M29.9999965S"
 
     # span = t1.until((ry.JiffUnit.Minute, t2))
     # assert span.string() == "PT725m29.9999965s"

--- a/tests/jiff/test_time_span.py
+++ b/tests/jiff/test_time_span.py
@@ -68,19 +68,19 @@ def test_negative_spans() -> None:
     assert_eq!(span.to_string(), "-P5d");
     """
     span = -ry.TimeSpan()._days(5)
-    assert span.string() == "-P5d"
+    assert span.string() == "-P5D"
 
     span = ry.TimeSpan()._days(5).negate()
-    assert span.string() == "-P5d"
+    assert span.string() == "-P5D"
 
     span = ry.TimeSpan()._days(-5)
-    assert span.string() == "-P5d"
+    assert span.string() == "-P5D"
 
     span = -ry.TimeSpan()._days(-5).negate()
-    assert span.string() == "-P5d"
+    assert span.string() == "-P5D"
 
     span = ry.TimeSpan()._days(-5)
-    assert span.string() == "-P5d"
+    assert span.string() == "-P5D"
 
 
 class TestSpanCheckedAdd:

--- a/tests/jiff/test_zoned_diff.py
+++ b/tests/jiff/test_zoned_diff.py
@@ -44,10 +44,10 @@ class TestZonedUntil:
         zdt2 = ry.date(2019, 1, 31).at(15, 30, 0, 0).intz("America/New_York")
 
         span = zdt1.until(zdt2)
-        assert str(span) == "PT202956h5m29.9999965s"
+        assert str(span) == "PT202956H5M29.9999965S"
 
         span = zdt1.until(("year", zdt2))
-        assert str(span) == "P23y1m24dT12h5m29.9999965s"
+        assert str(span) == "P23Y1M24DT12H5M29.9999965S"
 
     # def test_zoned_until_rounding_the_result(self) ->None:
     #     """


### PR DESCRIPTION
This pull request includes updates to the `jiff` library version and corresponding test cases to reflect changes in the string representation of time spans and durations. The most important changes include updating the `jiff` version in the `Cargo.toml` files and modifying test cases to use capital letters for time span strings.

Version update:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L137-R145): Updated `jiff` version from `0.1.16` to `0.1.21` and `serde_json` version from `1.0.134` to `1.0.135`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L137-R145) [[2]](diffhunk://#diff-24f5732b6bc2a43799285f75c003546b4fb99f5ecd3ac09215c6dcff03e8b224L13-R13)

Test case updates:

* [`tests/jiff/test_jiff.py`](diffhunk://#diff-09d7dd80491b5af2cedd9b3b6afbec0dcf751d28ad19de153d182e24526e8ef3L206-R211): Updated test cases to use capital letters for time span strings (e.g., "PT29341H3M" instead of "PT29341h3m"). [[1]](diffhunk://#diff-09d7dd80491b5af2cedd9b3b6afbec0dcf751d28ad19de153d182e24526e8ef3L206-R211) [[2]](diffhunk://#diff-09d7dd80491b5af2cedd9b3b6afbec0dcf751d28ad19de153d182e24526e8ef3L344-R344) [[3]](diffhunk://#diff-63b2f0a29cf73fb8329d11058db51aac258ae0c258a32f05f8c3f05a9c4ccba8L36-R36) [[4]](diffhunk://#diff-63b2f0a29cf73fb8329d11058db51aac258ae0c258a32f05f8c3f05a9c4ccba8L57-R57)
* [`tests/jiff/test_operators.py`](diffhunk://#diff-b12d45500a4487121afc4dfdb87a048a2ea8c90d99400fc1af9795d6ce282143L10-R10): Modified test cases to reflect the new time span string format with capital letters. [[1]](diffhunk://#diff-b12d45500a4487121afc4dfdb87a048a2ea8c90d99400fc1af9795d6ce282143L10-R10) [[2]](diffhunk://#diff-b12d45500a4487121afc4dfdb87a048a2ea8c90d99400fc1af9795d6ce282143L28-R28) [[3]](diffhunk://#diff-b12d45500a4487121afc4dfdb87a048a2ea8c90d99400fc1af9795d6ce282143L45-R45) [[4]](diffhunk://#diff-b12d45500a4487121afc4dfdb87a048a2ea8c90d99400fc1af9795d6ce282143L59-R59) [[5]](diffhunk://#diff-b12d45500a4487121afc4dfdb87a048a2ea8c90d99400fc1af9795d6ce282143L76-R76) [[6]](diffhunk://#diff-b12d45500a4487121afc4dfdb87a048a2ea8c90d99400fc1af9795d6ce282143L93-R93) [[7]](diffhunk://#diff-b12d45500a4487121afc4dfdb87a048a2ea8c90d99400fc1af9795d6ce282143L115-R115) [[8]](diffhunk://#diff-b12d45500a4487121afc4dfdb87a048a2ea8c90d99400fc1af9795d6ce282143L140-R140) [[9]](diffhunk://#diff-b12d45500a4487121afc4dfdb87a048a2ea8c90d99400fc1af9795d6ce282143L160-R160) [[10]](diffhunk://#diff-b12d45500a4487121afc4dfdb87a048a2ea8c90d99400fc1af9795d6ce282143L177-R177)
* [`tests/jiff/test_time.py`](diffhunk://#diff-762f92722b0f0fa68cd9cedac953ad6de8b437e4a267dbe9d3fd1f96faea2762L36-R36): Adjusted test cases to use the updated time span string format.
* [`tests/jiff/test_time_span.py`](diffhunk://#diff-60456ca3178bc53cc54ba9ffd7a9c2183d89f8f691002c53727650ea5259d788L71-R83): Updated negative span test cases to use capital letters in the string representation.
* [`tests/jiff/test_zoned_diff.py`](diffhunk://#diff-2aa37a2dda179659dd01348dfdf7929dedb38733733c0a9917140844c7d88ed0L47-R50): Modified test cases for zoned datetime differences to use capital letters in the time span strings.

Documentation update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R10): Added entry for version `0.0.25` with details on the `jiff` update.