### PR TITLE
no panics in jiff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.0.43 [unreleased]
 
+- `ryo3-jiff`
+  - panic-able functions to create new/altered (time)spans moved to use `try_*`
 - fix: anyio marker flat issue in pytests for cicd
 
 ---

--- a/crates/ryo3-jiff/src/ry_span.rs
+++ b/crates/ryo3-jiff/src/ry_span.rs
@@ -133,44 +133,44 @@ impl RySpan {
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("{e}")))
     }
 
-    fn _years(&self, n: i64) -> Self {
-        Self::from(self.0.years(n))
+    fn _years(&self, n: i64) -> PyResult<Self> {
+        self.try_years(n)
     }
 
-    fn _months(&self, n: i64) -> Self {
-        Self::from(self.0.months(n))
+    fn _months(&self, n: i64) -> PyResult<Self> {
+        self.try_months(n)
     }
 
-    fn _weeks(&self, n: i64) -> Self {
-        Self::from(self.0.weeks(n))
+    fn _weeks(&self, n: i64) -> PyResult<Self> {
+        self.try_weeks(n)
     }
 
-    fn _days(&self, n: i64) -> Self {
-        Self::from(self.0.days(n))
+    fn _days(&self, n: i64) -> PyResult<Self> {
+        self.try_days(n)
     }
 
-    fn _hours(&self, n: i64) -> Self {
-        Self::from(self.0.hours(n))
+    fn _hours(&self, n: i64) -> PyResult<Self> {
+        self.try_hours(n)
     }
 
-    fn _minutes(&self, n: i64) -> Self {
-        Self::from(self.0.minutes(n))
+    fn _minutes(&self, n: i64) -> PyResult<Self> {
+        self.try_minutes(n)
     }
 
-    fn _seconds(&self, n: i64) -> Self {
-        Self::from(self.0.seconds(n))
+    fn _seconds(&self, n: i64) -> PyResult<Self> {
+        self.try_seconds(n)
     }
 
-    fn _milliseconds(&self, n: i64) -> Self {
-        Self::from(self.0.milliseconds(n))
+    fn _milliseconds(&self, n: i64) -> PyResult<Self> {
+        self.try_milliseconds(n)
     }
 
-    fn _microseconds(&self, n: i64) -> Self {
-        Self::from(self.0.microseconds(n))
+    fn _microseconds(&self, n: i64) -> PyResult<Self> {
+        self.try_microseconds(n)
     }
 
-    fn _nanoseconds(&self, n: i64) -> Self {
-        Self::from(self.0.nanoseconds(n))
+    fn _nanoseconds(&self, n: i64) -> PyResult<Self> {
+        self.try_nanoseconds(n)
     }
 
     #[expect(clippy::too_many_arguments)]


### PR DESCRIPTION
# ai word salad

This pull request refactors the `ryo3-jiff` crate to make its time span manipulation functions safer by transitioning to panic-free, fallible methods. Additionally, a changelog entry was added to document this change.

### Refactoring for safer time span manipulation:
* Updated all time span manipulation methods in `impl RySpan` (e.g., `_years`, `_months`, `_days`, etc.) to use their corresponding `try_*` methods, returning `PyResult<Self>` instead of potentially panicking. This ensures that invalid inputs are handled gracefully. (`crates/ryo3-jiff/src/ry_span.rs`)

### Documentation updates:
* Added a changelog entry in `CHANGELOG.md` to document the migration of panic-able functions to their `try_*` equivalents. (`CHANGELOG.md`)