### PR TITLE
module name should be ry.ryo3

### DIFF
--- a/crates/ryo3-fspath/src/fspath.rs
+++ b/crates/ryo3-fspath/src/fspath.rs
@@ -16,7 +16,7 @@ const MAIN_SEPARATOR: char = std::path::MAIN_SEPARATOR;
 
 type ArcPathBuf = std::sync::Arc<PathBuf>;
 
-#[pyclass(name = "FsPath", module = "ry", frozen)]
+#[pyclass(name = "FsPath", module = "ry.ryo3", frozen)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PyFsPath {
     pth: ArcPathBuf,

--- a/crates/ryo3-glob/src/pattern.rs
+++ b/crates/ryo3-glob/src/pattern.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyString;
 use std::path::PathBuf;
 
-#[pyclass(name = "Pattern", module = "ry", frozen)]
+#[pyclass(name = "Pattern", module = "ry.ryo3", frozen)]
 #[derive(Debug, Clone)]
 pub struct PyPattern(pub(crate) glob::Pattern);
 

--- a/crates/ryo3-globset/src/globster.rs
+++ b/crates/ryo3-globset/src/globster.rs
@@ -15,7 +15,7 @@ pub struct Globster {
     pub length: usize,
 }
 
-#[pyclass(name = "Globster", frozen, module = "ryo3")]
+#[pyclass(name = "Globster", frozen, module = "ry.ryo3")]
 #[derive(Clone, Debug)]
 pub struct PyGlobster(pub Globster);
 

--- a/crates/ryo3-globset/src/lib.rs
+++ b/crates/ryo3-globset/src/lib.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 /// Default value for the `literal_separator` parameter.
 const DEFAULT_BACKSLASH_ESCAPE: bool = cfg!(windows);
 
-#[pyclass(name = "Glob", frozen, module = "ryo3")]
+#[pyclass(name = "Glob", frozen, module = "ry.ryo3")]
 #[derive(Clone, Debug)]
 pub struct PyGlob {
     pattern: String,
@@ -132,7 +132,7 @@ impl PyGlob {
     }
 }
 
-#[pyclass(name = "GlobSet", frozen, module = "ryo3")]
+#[pyclass(name = "GlobSet", frozen, module = "ry.ryo3")]
 #[derive(Clone, Debug)]
 pub struct PyGlobSet {
     globset: globset::GlobSet,

--- a/crates/ryo3-jiff/src/ry_date.rs
+++ b/crates/ryo3-jiff/src/ry_date.rs
@@ -25,7 +25,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::ops::Sub;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "Date", module = "ry", frozen)]
+#[pyclass(name = "Date", module = "ry.ryo3", frozen)]
 pub struct RyDate(pub(crate) Date);
 
 #[pymethods]
@@ -459,7 +459,7 @@ impl From<Date> for RyDate {
     }
 }
 
-#[pyclass(name = "DateSeries", module = "ryo3")]
+#[pyclass(name = "DateSeries", module = "ry.ryo3")]
 pub struct RyDateSeries {
     pub(crate) series: jiff::civil::DateSeries,
 }

--- a/crates/ryo3-jiff/src/ry_date_difference.rs
+++ b/crates/ryo3-jiff/src/ry_date_difference.rs
@@ -6,7 +6,7 @@ use jiff::civil::DateDifference;
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "DateDifference", module = "ryo3", frozen)]
+#[pyclass(name = "DateDifference", module = "ry.ryo3", frozen)]
 pub struct RyDateDifference(pub(crate) DateDifference);
 
 impl From<DateDifference> for RyDateDifference {

--- a/crates/ryo3-jiff/src/ry_datetime.rs
+++ b/crates/ryo3-jiff/src/ry_datetime.rs
@@ -20,7 +20,7 @@ use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::str::FromStr;
 #[derive(Debug, Clone)]
-#[pyclass(name = "DateTime", module = "ry", frozen)]
+#[pyclass(name = "DateTime", module = "ry.ryo3", frozen)]
 pub struct RyDateTime(pub(crate) DateTime);
 
 impl From<DateTime> for RyDateTime {
@@ -572,7 +572,7 @@ impl Display for RyDateTime {
     }
 }
 
-#[pyclass(name = "DateTimeSeries", module = "ryo3")]
+#[pyclass(name = "DateTimeSeries", module = "ry.ryo3")]
 pub struct RyDateTimeSeries {
     pub(crate) series: jiff::civil::DateTimeSeries,
 }

--- a/crates/ryo3-jiff/src/ry_datetime_difference.rs
+++ b/crates/ryo3-jiff/src/ry_datetime_difference.rs
@@ -6,7 +6,7 @@ use jiff::civil::DateTimeDifference;
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "DateTimeDifference", module = "ryo3", frozen)]
+#[pyclass(name = "DateTimeDifference", module = "ry.ryo3", frozen)]
 pub struct RyDateTimeDifference(pub(crate) DateTimeDifference);
 
 impl From<DateTimeDifference> for RyDateTimeDifference {

--- a/crates/ryo3-jiff/src/ry_datetime_round.rs
+++ b/crates/ryo3-jiff/src/ry_datetime_round.rs
@@ -3,7 +3,7 @@ use jiff::civil::DateTimeRound;
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "DateTimeRound", module = "ryo3", frozen)]
+#[pyclass(name = "DateTimeRound", module = "ry.ryo3", frozen)]
 pub struct RyDateTimeRound {
     pub smallest: JiffUnit,
     pub mode: JiffRoundMode,

--- a/crates/ryo3-jiff/src/ry_iso_week_date.rs
+++ b/crates/ryo3-jiff/src/ry_iso_week_date.rs
@@ -7,7 +7,7 @@ use pyo3::types::{PyTuple, PyType};
 use std::hash::{DefaultHasher, Hash, Hasher};
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "ISOWeekDate", module = "ry", frozen)]
+#[pyclass(name = "ISOWeekDate", module = "ry.ryo3", frozen)]
 pub struct RyISOWeekDate(pub(crate) ISOWeekDate);
 
 #[pymethods]

--- a/crates/ryo3-jiff/src/ry_offset.rs
+++ b/crates/ryo3-jiff/src/ry_offset.rs
@@ -13,7 +13,7 @@ use ryo3_std::PyDuration;
 use std::hash::{DefaultHasher, Hash, Hasher};
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "Offset", module = "ry", frozen)]
+#[pyclass(name = "Offset", module = "ry.ryo3", frozen)]
 pub struct RyOffset(pub(crate) Offset);
 
 #[pymethods]

--- a/crates/ryo3-jiff/src/ry_signed_duration.rs
+++ b/crates/ryo3-jiff/src/ry_signed_duration.rs
@@ -13,7 +13,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::str::FromStr;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "SignedDuration", module = "ry", frozen)]
+#[pyclass(name = "SignedDuration", module = "ry.ryo3", frozen)]
 pub struct RySignedDuration(pub(crate) SignedDuration);
 
 #[pymethods]

--- a/crates/ryo3-jiff/src/ry_span.rs
+++ b/crates/ryo3-jiff/src/ry_span.rs
@@ -13,7 +13,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::str::FromStr;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "TimeSpan", module = "ry", frozen)]
+#[pyclass(name = "TimeSpan", module = "ry.ryo3", frozen)]
 pub struct RySpan(pub(crate) Span);
 
 #[pymethods]

--- a/crates/ryo3-jiff/src/ry_time.rs
+++ b/crates/ryo3-jiff/src/ry_time.rs
@@ -16,7 +16,7 @@ use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::ops::Sub;
 use std::str::FromStr;
-#[pyclass(name = "Time", module = "ry", frozen)]
+#[pyclass(name = "Time", module = "ry.ryo3", frozen)]
 #[derive(Debug, Clone)]
 pub struct RyTime(pub(crate) jiff::civil::Time);
 
@@ -444,7 +444,7 @@ impl From<JiffTime> for RyTime {
     }
 }
 
-#[pyclass(name = "TimeSeries", module = "ryo3")]
+#[pyclass(name = "TimeSeries", module = "ry.ryo3")]
 pub struct RyTimeSeries {
     pub(crate) series: jiff::civil::TimeSeries,
 }

--- a/crates/ryo3-jiff/src/ry_time_difference.rs
+++ b/crates/ryo3-jiff/src/ry_time_difference.rs
@@ -6,7 +6,7 @@ use jiff::civil::TimeDifference;
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "TimeDifference", module = "ryo3", frozen)]
+#[pyclass(name = "TimeDifference", module = "ry.ryo3", frozen)]
 pub struct RyTimeDifference(pub(crate) TimeDifference);
 
 impl From<TimeDifference> for RyTimeDifference {

--- a/crates/ryo3-jiff/src/ry_timestamp.rs
+++ b/crates/ryo3-jiff/src/ry_timestamp.rs
@@ -19,7 +19,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::str::FromStr;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "Timestamp", module = "ry", frozen)]
+#[pyclass(name = "Timestamp", module = "ry.ryo3", frozen)]
 pub struct RyTimestamp(pub(crate) Timestamp);
 
 #[pymethods]
@@ -425,7 +425,7 @@ impl From<Timestamp> for RyTimestamp {
     }
 }
 
-#[pyclass(name = "TimestampSeries", module = "ryo3")]
+#[pyclass(name = "TimestampSeries", module = "ry.ryo3")]
 pub struct RyTimestampSeries {
     pub(crate) series: jiff::TimestampSeries,
 }

--- a/crates/ryo3-jiff/src/ry_timestamp_difference.rs
+++ b/crates/ryo3-jiff/src/ry_timestamp_difference.rs
@@ -5,7 +5,7 @@ use jiff::TimestampDifference;
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "TimestampDifference", module = "ryo3", frozen)]
+#[pyclass(name = "TimestampDifference", module = "ry.ryo3", frozen)]
 pub struct RyTimestampDifference(pub(crate) TimestampDifference);
 
 impl From<TimestampDifference> for RyTimestampDifference {

--- a/crates/ryo3-jiff/src/ry_timestamp_round.rs
+++ b/crates/ryo3-jiff/src/ry_timestamp_round.rs
@@ -3,7 +3,7 @@ use jiff::TimestampRound;
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "TimestampRound", module = "ryo3", frozen)]
+#[pyclass(name = "TimestampRound", module = "ry.ryo3", frozen)]
 pub struct RyTimestampRound {
     pub smallest: JiffUnit,
     pub mode: JiffRoundMode,

--- a/crates/ryo3-jiff/src/ry_timezone.rs
+++ b/crates/ryo3-jiff/src/ry_timezone.rs
@@ -13,7 +13,7 @@ use std::fmt::Debug;
 use std::hash::{DefaultHasher, Hash, Hasher};
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "TimeZone", module = "ry", frozen)]
+#[pyclass(name = "TimeZone", module = "ry.ryo3", frozen)]
 pub struct RyTimeZone(pub(crate) TimeZone);
 
 impl From<TimeZone> for RyTimeZone {

--- a/crates/ryo3-jiff/src/ry_timezone_database.rs
+++ b/crates/ryo3-jiff/src/ry_timezone_database.rs
@@ -3,7 +3,7 @@ use crate::RyTimeZone;
 use jiff::tz::TimeZoneDatabase;
 use pyo3::prelude::*;
 use pyo3::types::PyType;
-#[pyclass(name = "TimeZoneDatabase", module = "ryo3", frozen)]
+#[pyclass(name = "TimeZoneDatabase", module = "ry.ryo3", frozen)]
 #[derive(Debug, Clone)]
 pub struct RyTimeZoneDatabase {
     inner: Option<TimeZoneDatabase>,

--- a/crates/ryo3-jiff/src/ry_weekday.rs
+++ b/crates/ryo3-jiff/src/ry_weekday.rs
@@ -1,6 +1,6 @@
 use pyo3::prelude::*;
 
-#[pyclass(name = "Weekday", module = "ryo3", frozen)]
+#[pyclass(name = "Weekday", module = "ry.ryo3", frozen)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RyWeekday(pub(crate) jiff::civil::Weekday);
 

--- a/crates/ryo3-jiff/src/ry_zoned.rs
+++ b/crates/ryo3-jiff/src/ry_zoned.rs
@@ -23,7 +23,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::str::FromStr;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "ZonedDateTime", module = "ry", frozen)]
+#[pyclass(name = "ZonedDateTime", module = "ry.ryo3", frozen)]
 pub struct RyZoned(pub(crate) Zoned);
 
 #[pymethods]

--- a/crates/ryo3-jiff/src/ry_zoned_difference.rs
+++ b/crates/ryo3-jiff/src/ry_zoned_difference.rs
@@ -4,7 +4,7 @@ use jiff::Unit;
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "ZonedDateTimeDifference", module = "ryo3", frozen)]
+#[pyclass(name = "ZonedDateTimeDifference", module = "ry.ryo3", frozen)]
 pub struct RyZonedDifference {
     zoned: RyZoned,
     smallest: Option<Unit>,

--- a/crates/ryo3-jiff/src/ry_zoned_round.rs
+++ b/crates/ryo3-jiff/src/ry_zoned_round.rs
@@ -3,7 +3,7 @@ use jiff::ZonedRound;
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "ZonedDateTimeRound", module = "ryo3", frozen)]
+#[pyclass(name = "ZonedDateTimeRound", module = "ry.ryo3", frozen)]
 pub struct RyZonedDateTimeRound {
     pub smallest: JiffUnit,
     pub mode: JiffRoundMode,

--- a/crates/ryo3-size/src/py_size.rs
+++ b/crates/ryo3-size/src/py_size.rs
@@ -6,7 +6,7 @@ use pyo3::types::{PyTuple, PyType};
 use std::ops::{Mul, Neg, Not};
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "Size", module = "ry", frozen)]
+#[pyclass(name = "Size", module = "ry.ryo3", frozen)]
 pub struct PySize(size::Size);
 
 #[pymethods]

--- a/crates/ryo3-size/src/size_formatter.rs
+++ b/crates/ryo3-size/src/size_formatter.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyTuple;
 use pyo3::{intern, IntoPyObjectExt};
 
-#[pyclass(name = "SizeFormatter", module = "ry", frozen)]
+#[pyclass(name = "SizeFormatter", module = "ry.ryo3", frozen)]
 pub struct PySizeFormatter {
     formatter: size::fmt::SizeFormatter,
     base: Base,

--- a/crates/ryo3-sqlformat/src/lib.rs
+++ b/crates/ryo3-sqlformat/src/lib.rs
@@ -5,7 +5,7 @@ use sqlformat::{self, QueryParams};
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
-#[pyclass(name = "SqlfmtQueryParams", module = "ryo3", frozen)]
+#[pyclass(name = "SqlfmtQueryParams", module = "ry.ryo3", frozen)]
 #[derive(Debug, Clone)]
 pub struct PySqlfmtQueryParams {
     pub params: QueryParams,

--- a/crates/ryo3-std/src/fs/file_read_stream.rs
+++ b/crates/ryo3-std/src/fs/file_read_stream.rs
@@ -56,7 +56,7 @@ impl Iterator for FileReadStream {
     }
 }
 
-#[pyclass(name = "FileReadStream", module = "ryo3", frozen)]
+#[pyclass(name = "FileReadStream", module = "ry.ryo3", frozen)]
 pub struct PyFileReadStream {
     pub(crate) file_read_stream: Mutex<FileReadStream>,
 }

--- a/crates/ryo3-std/src/fs/mod.rs
+++ b/crates/ryo3-std/src/fs/mod.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::SystemTime;
 
-#[pyclass(name = "FileType", module = "ry", frozen)]
+#[pyclass(name = "FileType", module = "ry.ryo3", frozen)]
 pub struct PyFileType(pub std::fs::FileType);
 impl PyFileType {
     #[must_use]
@@ -58,7 +58,7 @@ impl PyFileType {
     }
 }
 
-#[pyclass(name = "Metadata", module = "ry", frozen)]
+#[pyclass(name = "Metadata", module = "ry.ryo3", frozen)]
 pub struct PyMetadata(pub std::fs::Metadata);
 
 impl From<std::fs::Metadata> for PyMetadata {
@@ -143,7 +143,7 @@ impl PyMetadata {
     }
 }
 
-#[pyclass(name = "Permissions", module = "ry", frozen)]
+#[pyclass(name = "Permissions", module = "ry.ryo3", frozen)]
 pub struct PyPermissions(pub std::fs::Permissions);
 
 impl From<std::fs::Permissions> for PyPermissions {

--- a/crates/ryo3-std/src/time/duration.rs
+++ b/crates/ryo3-std/src/time/duration.rs
@@ -15,7 +15,7 @@ const MAX_DAYS: u64 = u64::MAX / (SECS_PER_MINUTE * MINS_PER_HOUR * HOURS_PER_DA
 const MAX_WEEKS: u64 = u64::MAX / (SECS_PER_MINUTE * MINS_PER_HOUR * HOURS_PER_DAY * DAYS_PER_WEEK);
 
 #[derive(Debug, Clone, PartialEq)]
-#[pyclass(name = "Duration", module = "ry", frozen)]
+#[pyclass(name = "Duration", module = "ry.ryo3", frozen)]
 pub struct PyDuration(pub Duration);
 
 #[pymethods]

--- a/crates/ryo3-std/src/time/instant.rs
+++ b/crates/ryo3-std/src/time/instant.rs
@@ -8,7 +8,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::time::Instant;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "Instant", module = "ry", frozen)]
+#[pyclass(name = "Instant", module = "ry.ryo3", frozen)]
 pub struct PyInstant(pub Instant);
 
 impl From<Instant> for PyInstant {

--- a/crates/ryo3-url/src/py_url.rs
+++ b/crates/ryo3-url/src/py_url.rs
@@ -8,7 +8,7 @@ use std::net::IpAddr;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
-#[pyclass(name = "URL", module = "ry", frozen)]
+#[pyclass(name = "URL", module = "ry.ryo3", frozen)]
 pub struct PyUrl(pub url::Url);
 
 impl PyUrl {

--- a/crates/ryo3-xxhash/src/xxhashers.rs
+++ b/crates/ryo3-xxhash/src/xxhashers.rs
@@ -4,7 +4,7 @@ use xxhash_rust::xxh3::{Xxh3, Xxh3Builder};
 use xxhash_rust::xxh32::Xxh32;
 use xxhash_rust::xxh64::Xxh64;
 
-#[pyclass(name = "Xxh32", module = "ry.xxhash")]
+#[pyclass(name = "Xxh32", module = "ry.ryo3.xxhash")]
 pub struct PyXxh32 {
     seed: u32,
     pub hasher: Xxh32,
@@ -88,7 +88,7 @@ pub fn xxh32(s: Option<ryo3_bytes::PyBytes>, seed: Option<u32>) -> PyResult<PyXx
 }
 
 /// Python-Xxh64 hasher
-#[pyclass(name = "Xxh64", module = "ry.xxhash")]
+#[pyclass(name = "Xxh64", module = "ry.ryo3.xxhash")]
 pub struct PyXxh64 {
     seed: u64,
     pub hasher: Xxh64,
@@ -173,7 +173,7 @@ pub fn xxh64(s: Option<ryo3_bytes::PyBytes>, seed: Option<u64>) -> PyResult<PyXx
     Ok(PyXxh64::py_new(s, seed))
 }
 
-#[pyclass(name = "Xxh3", module = "ry.xxhash")]
+#[pyclass(name = "Xxh3", module = "ry.ryo3.xxhash")]
 pub struct PyXxh3 {
     seed: u64,
     pub hasher: Xxh3,

--- a/crates/ryo3-xxhash/src/xxhashers.rs
+++ b/crates/ryo3-xxhash/src/xxhashers.rs
@@ -4,7 +4,7 @@ use xxhash_rust::xxh3::{Xxh3, Xxh3Builder};
 use xxhash_rust::xxh32::Xxh32;
 use xxhash_rust::xxh64::Xxh64;
 
-#[pyclass(name = "Xxh32", module = "ryo3")]
+#[pyclass(name = "Xxh32", module = "ry.xxhash")]
 pub struct PyXxh32 {
     seed: u32,
     pub hasher: Xxh32,
@@ -88,7 +88,7 @@ pub fn xxh32(s: Option<ryo3_bytes::PyBytes>, seed: Option<u32>) -> PyResult<PyXx
 }
 
 /// Python-Xxh64 hasher
-#[pyclass(name = "Xxh64", module = "ryo3")]
+#[pyclass(name = "Xxh64", module = "ry.xxhash")]
 pub struct PyXxh64 {
     seed: u64,
     pub hasher: Xxh64,
@@ -173,7 +173,7 @@ pub fn xxh64(s: Option<ryo3_bytes::PyBytes>, seed: Option<u64>) -> PyResult<PyXx
     Ok(PyXxh64::py_new(s, seed))
 }
 
-#[pyclass(name = "Xxh3", module = "ryo3")]
+#[pyclass(name = "Xxh3", module = "ry.xxhash")]
 pub struct PyXxh3 {
     seed: u64,
     pub hasher: Xxh3,

--- a/tests/globset/test_globset.py
+++ b/tests/globset/test_globset.py
@@ -7,21 +7,21 @@ def test_glob_str_repr_methods() -> None:
     glob = ry.Glob("*.py")
     assert str(glob) == 'Glob("*.py")'
     assert repr(glob) == str(glob)
-    assert glob.__module__ == "ryo3"
+    assert glob.__module__ == "ry.ryo3"
 
 
 def test_globset_str_repr_methods() -> None:
     globset = ry.GlobSet(["*.py", "*.txt"])
     assert str(globset) == 'GlobSet(["*.py", "*.txt"])'
     assert str(globset) == repr(globset)
-    assert globset.__module__ == "ryo3"
+    assert globset.__module__ == "ry.ryo3"
 
 
 def test_globster_str_repr_methods() -> None:
     globset = ry.globster(["*.py", "*.txt"])
     assert str(globset) == 'Globster(["*.py", "*.txt"])'
     assert str(globset) == repr(globset)
-    assert globset.__module__ == "ryo3"
+    assert globset.__module__ == "ry.ryo3"
 
 
 def test_single_globster() -> None:

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -48,6 +48,9 @@ def test_exports_module_attr_param(name: str) -> None:
     module_name = member.__module__
     assert module_name is not None, f"{name} has no __module__"
     assert module_name != "builtins", f"{name} is builtin"
+    assert module_name.startswith("ry.ryo3")
     assert any(
-        module_name.startswith(prefix) for prefix in ("ry", "ryo3", "ry.ryo3")
+        # module_name.startswith(prefix) for prefix in ("ry", "ryo3", "ry.ryo3")
+        module_name.startswith(prefix)
+        for prefix in ("ry", "ry.ryo3")
     ), f"{name} {member} is not in ry"


### PR DESCRIPTION
change module names for structs at root level to be `ry.ryo3`

# ai word salad

This pull request standardizes the `module` attribute for all `#[pyclass]` annotations across various files by updating the module path from `ry` or `ryo3` to `ry.ryo3`. This change ensures consistency in the module naming convention for Python bindings generated by the `pyo3` library.

### Changes to module paths for Python bindings:

* Updated the `module` attribute in `#[pyclass]` annotations for `FsPath` in `fspath.rs` to use `ry.ryo3` instead of `ry`.
* Updated the `module` attribute in `#[pyclass]` annotations for `Pattern` in `pattern.rs` to use `ry.ryo3` instead of `ry`.
* Updated the `module` attribute in `#[pyclass]` annotations for `Globster`, `Glob`, and `GlobSet` in `globster.rs` and `lib.rs` to use `ry.ryo3` instead of `ryo3`. [[1]](diffhunk://#diff-f8dcd2f7065032afe519eef46963f9496c4646214c62d76f32bed4005a59f6b8L18-R18) [[2]](diffhunk://#diff-930005bf0c6ff1d9826733decf3bbb6ad36251706b21362979904f1a4620383eL15-R15) [[3]](diffhunk://#diff-930005bf0c6ff1d9826733decf3bbb6ad36251706b21362979904f1a4620383eL135-R135)

### Changes to date and time-related Python bindings:

* Updated the `module` attribute in `#[pyclass]` annotations for `Date`, `DateSeries`, `DateTime`, `DateTimeSeries`, `Time`, `TimeSeries`, `Timestamp`, and `TimestampSeries` in respective files to use `ry.ryo3` instead of `ry` or `ryo3`. [[1]](diffhunk://#diff-685d25e264f13f8225a09dde7b6ccaefa9a3a25fd22ff56ee613ded4caa5805bL28-R28) [[2]](diffhunk://#diff-685d25e264f13f8225a09dde7b6ccaefa9a3a25fd22ff56ee613ded4caa5805bL462-R462) [[3]](diffhunk://#diff-d09437bbc50fe18450ae2044b4b2031296d777d74b4cf02b5bbb86d6f3272fcaL23-R23) [[4]](diffhunk://#diff-d09437bbc50fe18450ae2044b4b2031296d777d74b4cf02b5bbb86d6f3272fcaL575-R575) [[5]](diffhunk://#diff-fceaaabdcdc06f7cec6118b3a40824ea588f60578b32d2bc7c4591ea861e8b34L19-R19) [[6]](diffhunk://#diff-fceaaabdcdc06f7cec6118b3a40824ea588f60578b32d2bc7c4591ea861e8b34L447-R447) F8c31f5fL13R13, [[7]](diffhunk://#diff-023e42805787a2c8f06fc6dcbb955a50a59aeffefc8c1eb2e0e98b766d8fe886L428-R428)

### Changes to difference and rounding-related Python bindings:

* Updated the `module` attribute in `#[pyclass]` annotations for `DateDifference`, `DateTimeDifference`, `TimeDifference`, `TimestampDifference`, `DateTimeRound`, and `TimestampRound` in respective files to use `ry.ryo3` instead of `ry` or `ryo3`. [[1]](diffhunk://#diff-90663032081c733eada223f27acced1a65c821e59e56ae4a48c0fc7f3f0526a5L9-R9) [[2]](diffhunk://#diff-ea9c92c9de6c00a1c0397ad7723addb30a57d683c1a9768b56cd630208c6af6eL9-R9) [[3]](diffhunk://#diff-dd1176352ada930de4e3ca280c8ad4689a593224a061cb147cf93f04ab608525L9-R9) [[4]](diffhunk://#diff-cfa4188a6be3137b1bdb759b5283611ce8b3dac955c97212ce5a29c2ee4c77bbL8-R8) [[5]](diffhunk://#diff-80c6f16871528b151dadbd9ad1b7ca5d320872c1dfb36b21c407fa03a9120dd3L6-R6) [[6]](diffhunk://#diff-637e142b7d931ea594da565bad52e5c178e32b872fcd78761088cbb0fa7ef4ebL6-R6)

### Changes to other Python bindings:

* Updated the `module` attribute in `#[pyclass]` annotations for `ISOWeekDate`, `Offset`, `SignedDuration`, `TimeSpan`, `TimeZone`, and `TimeZoneDatabase` in respective files to use `ry.ryo3` instead of `ry` or `ryo3`. [[1]](diffhunk://#diff-5b1d89c489ab08bb937cb84dcb3d95313034c6c5eb8f0b586bdbfc50b9dc33b8L10-R10) [[2]](diffhunk://#diff-a3b136e18dc1a9eff083cc899485063f665790b59857a0dce15421b5b7ef7b1eL16-R16) [[3]](diffhunk://#diff-113883407c4df9e66f96df5fc2917a75b3aa6a509530e9c57b117753410c9119L16-R16) [[4]](diffhunk://#diff-5324cbdb3caf79c4c699550bc00be83a95f73cbc2ad81d4113ca3391f4e50231L16-R16) [[5]](diffhunk://#diff-400f3ecc855b51893314b152ec4523d8e96f56af8fd9ac98c550b007becfe415L16-R16) [[6]](diffhunk://#diff-945d309d0a8f49ec05dcda4bac881c3e0b54c59e72f400dd6ddb030174386907L6-R6)