### PR TITLE
serde + types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1784,6 +1784,8 @@ dependencies = [
  "pyo3-build-config",
  "ryo3-macros",
  "ryo3-std",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -708,9 +708,9 @@ checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -724,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -805,9 +805,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02000660d30638906021176af16b17498bd0d12813dbfe7b276d8bc7f3c0806"
+checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -820,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c30758ddd7188629c6713fc45d1188af4f44c90582311d0c8d8c9907f60c48"
+checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2710,9 +2710,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,20 +154,20 @@ pyo3-async-runtimes = { version = "0.25.0", features = ["tokio-runtime"] }
 
 # external
 ahash = "0.8.12"
-anyhow = "1.0.75"
+anyhow = "1.0"
 brotli = "8.0.1"
 bytes = "1.10.1"
-bzip2 = "0.5.1"
+bzip2 = "0.5.2"
 dirs = { version = "6.0.0", features = [] }
 fnv = "1.0.7"
 flate2 = "1.1.1"
 futures-core = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3"
-globset = { version = "0.4.15", features = ["serde"] }
+globset = { version = "0.4.16", features = ["serde"] }
 heck = "0.5.0"
 http = "1.3.1"
-jiff = { version = "0.2.13", features = ["default", "serde"] }
+jiff = { version = "0.2.14", features = ["default", "serde"] }
 jiter = { version = "0.10.0", features = ["python"] }
 parking_lot = "0.12.3"
 regex = "1.11.1"
@@ -189,7 +189,7 @@ uuid = { version = "1.16.0", features = ["v4", "v8"] }
 walkdir = "2.5.0"
 which = { version = "7.0.3", features = [] }
 xxhash-rust = { version = "0.8.15", features = ["const_xxh3", "const_xxh32", "const_xxh64", "xxh3", "xxh32", "xxh64"] }
-zstd = "0.13.2"
+zstd = "0.13.3"
 zstd-safe = "7.2.4"
 
 [workspace.lints.rust]

--- a/crates/ryo3-jiff/Cargo.toml
+++ b/crates/ryo3-jiff/Cargo.toml
@@ -13,12 +13,26 @@ categories.workspace = true
 
 [dependencies]
 ryo3-std = { workspace = true }
-pyo3 = { workspace = true, features = [ "jiff-02"] }
+pyo3 = { workspace = true, features = ["jiff-02"] }
 ryo3-macros.workspace = true
 jiff.workspace = true
+serde = { workspace = true, features = ["derive"], optional = true }
+
+[dev-dependencies]
+serde_json.workspace = true
+serde = { workspace = true, features = ["derive"] }
 
 [build-dependencies]
-pyo3-build-config = {workspace = true}
+pyo3-build-config = { workspace = true }
+
+[features]
+default = [
+  "serde"
+]
+serde = [
+  "dep:serde",
+  "jiff/serde",
+]
 
 [lints]
 workspace = true

--- a/crates/ryo3-jiff/src/lib.rs
+++ b/crates/ryo3-jiff/src/lib.rs
@@ -10,7 +10,7 @@
 #![deny(clippy::missing_panics_doc)]
 #![deny(clippy::arithmetic_side_effects)]
 #![expect(clippy::missing_errors_doc)]
-#![expect(clippy::unsafe_derive_deserialize)]
+#![cfg_attr(feature = "serde", expect(clippy::unsafe_derive_deserialize))]
 extern crate core;
 
 pub mod pydatetime_conversions;

--- a/crates/ryo3-jiff/src/lib.rs
+++ b/crates/ryo3-jiff/src/lib.rs
@@ -10,6 +10,7 @@
 #![deny(clippy::missing_panics_doc)]
 #![deny(clippy::arithmetic_side_effects)]
 #![expect(clippy::missing_errors_doc)]
+#![expect(clippy::unsafe_derive_deserialize)]
 extern crate core;
 
 pub mod pydatetime_conversions;
@@ -44,6 +45,7 @@ mod ry_zoned;
 mod ry_zoned_difference;
 mod ry_zoned_round;
 mod span_relative_to;
+mod test;
 
 pub use api::*;
 pub use jiff_types::*;

--- a/crates/ryo3-jiff/src/ry_date.rs
+++ b/crates/ryo3-jiff/src/ry_date.rs
@@ -24,8 +24,10 @@ use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::ops::Sub;
 
-#[derive(Debug, Clone)]
 #[pyclass(name = "Date", module = "ry.ryo3", frozen)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct RyDate(pub(crate) Date);
 
 #[pymethods]
@@ -63,7 +65,13 @@ impl RyDate {
         Self::from(z)
     }
 
-    fn at(&self, hour: i8, minute: i8, second: i8, subsec_nanosecond: i32) -> RyDateTime {
+    pub(crate) fn at(
+        &self,
+        hour: i8,
+        minute: i8,
+        second: i8,
+        subsec_nanosecond: i32,
+    ) -> RyDateTime {
         RyDateTime::from(self.0.at(hour, minute, second, subsec_nanosecond))
     }
 

--- a/crates/ryo3-jiff/src/ry_datetime.rs
+++ b/crates/ryo3-jiff/src/ry_datetime.rs
@@ -19,9 +19,34 @@ use std::borrow::BorrowMut;
 use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::str::FromStr;
-#[derive(Debug, Clone)]
+
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 #[pyclass(name = "DateTime", module = "ry.ryo3", frozen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct RyDateTime(pub(crate) DateTime);
+
+// impl Serialize for RyDateTime {
+//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+//     where
+//         S: serde::Serializer,
+//     {
+//         serializer.serialize_str(&self.to_string())
+//     }
+// }
+//
+// impl Deserialize<'_> for RyDateTime {
+//     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+//     where
+//         D: Deserializer<'_>
+//     {
+//
+//         let s = String::deserialize(deserializer)?;
+//         DateTime::from_str(&s)
+//             .map(RyDateTime)
+//             .map_err(serde::de::Error::custom)
+//     }
+// }
 
 impl From<DateTime> for RyDateTime {
     fn from(value: DateTime) -> Self {
@@ -309,7 +334,7 @@ impl RyDateTime {
         RyDate::from(self.0.date())
     }
 
-    fn in_tz(&self, tz: &str) -> PyResult<RyZoned> {
+    pub(crate) fn in_tz(&self, tz: &str) -> PyResult<RyZoned> {
         self.0
             .in_tz(tz)
             .map(RyZoned::from)

--- a/crates/ryo3-jiff/src/ry_datetime.rs
+++ b/crates/ryo3-jiff/src/ry_datetime.rs
@@ -26,28 +26,6 @@ use std::str::FromStr;
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct RyDateTime(pub(crate) DateTime);
 
-// impl Serialize for RyDateTime {
-//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-//     where
-//         S: serde::Serializer,
-//     {
-//         serializer.serialize_str(&self.to_string())
-//     }
-// }
-//
-// impl Deserialize<'_> for RyDateTime {
-//     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-//     where
-//         D: Deserializer<'_>
-//     {
-//
-//         let s = String::deserialize(deserializer)?;
-//         DateTime::from_str(&s)
-//             .map(RyDateTime)
-//             .map_err(serde::de::Error::custom)
-//     }
-// }
-
 impl From<DateTime> for RyDateTime {
     fn from(value: DateTime) -> Self {
         RyDateTime(value)

--- a/crates/ryo3-jiff/src/ry_signed_duration.rs
+++ b/crates/ryo3-jiff/src/ry_signed_duration.rs
@@ -16,7 +16,9 @@ use std::str::FromStr;
 
 const NANOS_PER_SEC: i32 = 1_000_000_000;
 
-#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[derive(Debug, Clone, PartialOrd, PartialEq)]
 #[pyclass(name = "SignedDuration", module = "ry.ryo3", frozen)]
 pub struct RySignedDuration(pub(crate) SignedDuration);
 
@@ -38,7 +40,7 @@ impl RySignedDuration {
 impl RySignedDuration {
     #[new]
     #[pyo3(signature = (secs = 0, nanos = 0))]
-    fn py_new(secs: i64, nanos: i32) -> PyResult<Self> {
+    pub fn py_new(secs: i64, nanos: i32) -> PyResult<Self> {
         #[expect(clippy::cast_lossless)]
         if !(-NANOS_PER_SEC < nanos && nanos < NANOS_PER_SEC) {
             let addsecs = nanos / NANOS_PER_SEC;

--- a/crates/ryo3-jiff/src/ry_span.rs
+++ b/crates/ryo3-jiff/src/ry_span.rs
@@ -12,9 +12,19 @@ use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::str::FromStr;
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 #[derive(Debug, Clone)]
 #[pyclass(name = "TimeSpan", module = "ry.ryo3", frozen)]
 pub struct RySpan(pub(crate) Span);
+
+impl PartialEq for RySpan {
+    fn eq(&self, other: &Self) -> bool {
+        let self_fieldwise = self.0.fieldwise();
+        let other_fieldwise = other.0.fieldwise();
+        self_fieldwise == other_fieldwise
+    }
+}
 
 #[pymethods]
 impl RySpan {
@@ -35,7 +45,7 @@ impl RySpan {
             nanoseconds=0
         )
     )]
-    fn py_new(
+    pub fn py_new(
         years: i64,
         months: i64,
         weeks: i64,
@@ -694,6 +704,7 @@ impl RySpan {
         }
     }
 }
+
 impl Display for RySpan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)

--- a/crates/ryo3-jiff/src/ry_time.rs
+++ b/crates/ryo3-jiff/src/ry_time.rs
@@ -16,9 +16,12 @@ use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::ops::Sub;
 use std::str::FromStr;
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[pyclass(name = "Time", module = "ry.ryo3", frozen)]
-#[derive(Debug, Clone)]
-pub struct RyTime(pub(crate) jiff::civil::Time);
+pub struct RyTime(pub(crate) Time);
 
 #[pymethods]
 impl RyTime {
@@ -253,10 +256,12 @@ impl RyTime {
     // =====================================================================
     // PYTHON CONVERSIONS
     // =====================================================================
+    #[expect(clippy::wrong_self_convention)]
     fn to_py(&self) -> Time {
         self.to_pytime()
     }
 
+    #[expect(clippy::wrong_self_convention)]
     fn to_pytime(&self) -> Time {
         self.0
     }
@@ -346,6 +351,7 @@ impl RyTime {
         }
     }
 
+    #[expect(clippy::wrong_self_convention)]
     fn to_datetime(&self, date: &crate::RyDate) -> RyDateTime {
         RyDateTime::from(self.0.to_datetime(date.0))
     }

--- a/crates/ryo3-jiff/src/ry_timestamp.rs
+++ b/crates/ryo3-jiff/src/ry_timestamp.rs
@@ -18,7 +18,9 @@ use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::str::FromStr;
 
-#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 #[pyclass(name = "Timestamp", module = "ry.ryo3", frozen)]
 pub struct RyTimestamp(pub(crate) Timestamp);
 

--- a/crates/ryo3-jiff/src/ry_zoned.rs
+++ b/crates/ryo3-jiff/src/ry_zoned.rs
@@ -22,7 +22,9 @@ use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::str::FromStr;
 
-#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[derive(Debug, Clone, PartialEq)]
 #[pyclass(name = "ZonedDateTime", module = "ry.ryo3", frozen)]
 pub struct RyZoned(pub(crate) Zoned);
 
@@ -35,6 +37,7 @@ impl RyZoned {
         let tz = time_zone.0;
         Ok(RyZoned::from(Zoned::new(ts, tz)))
     }
+
     fn __getnewargs__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
         PyTuple::new(
             py,

--- a/crates/ryo3-jiff/src/test.rs
+++ b/crates/ryo3-jiff/src/test.rs
@@ -1,0 +1,45 @@
+#![cfg(test)]
+
+use crate::{RyDate, RyDateTime, RySignedDuration, RySpan, RyTime, RyTimestamp, RyZoned};
+use jiff::Span;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct Stuff {
+    date: RyDate,
+    datetime: RyDateTime,
+    signed_duration: RySignedDuration,
+    span: RySpan,
+    time: RyTime,
+    timestamp: RyTimestamp,
+    zoned: RyZoned,
+}
+
+// the test
+#[test]
+fn test_deserialize_and_serialize() {
+    let ry_time = RyTime::py_new(Some(4), Some(3), Some(2), Option::from(1)).unwrap();
+    let ry_date = RyDate::py_new(2025, 5, 21).unwrap();
+    let ry_datetime = ry_date.at(4, 3, 2, 1);
+    let ry_zoned = ry_datetime.in_tz("America/New_York").unwrap();
+    let ry_signed_duration = RySignedDuration::py_new(123, 123).unwrap();
+    let ry_timestamp = RyTimestamp::py_new(Some(1234), Some(5678)).unwrap();
+    let span = Span::new().days(1).hours(2).minutes(4);
+    let ry_span = RySpan::from(span);
+
+    let s = Stuff {
+        date: ry_date,
+        datetime: ry_datetime,
+        signed_duration: ry_signed_duration,
+        span: ry_span,
+        time: ry_time,
+        timestamp: ry_timestamp,
+        zoned: ry_zoned,
+    };
+
+    let serialized = serde_json::to_string_pretty(&s).unwrap();
+
+    println!("Serialized: {}", serialized);
+    let deserialized: Stuff = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(s, deserialized);
+}

--- a/crates/ryo3-reqwest/src/response_parking_lot.rs
+++ b/crates/ryo3-reqwest/src/response_parking_lot.rs
@@ -173,6 +173,11 @@ impl RyResponse {
         })
     }
 
+    /// Return a response consuming async iterator over the response body
+    fn stream(&self) -> PyResult<RyResponseStream> {
+        self.bytes_stream()
+    }
+
     #[getter]
     fn content_encoding(&self) -> Option<String> {
         self.head.headers.get(CONTENT_ENCODING).map(|en| {

--- a/python/ry/ryo3/_reqwest.pyi
+++ b/python/ry/ryo3/_reqwest.pyi
@@ -1,13 +1,22 @@
 import typing as t
 
-from typing_extensions import TypeAlias
+import typing_extensions as te
 
 import ry
 from ry._types import Buffer
 from ry.http import Headers, HttpStatus, HttpVersionLike
 from ry.ryo3 import URL, Duration
 
-HeadersLike: TypeAlias = Headers | dict[str, str]
+HeadersLike: te.TypeAlias = Headers | dict[str, str]
+
+class RequestKwargs(t.TypedDict, total=False):
+    body: Buffer | None
+    headers: HeadersLike | None
+    query: dict[str, t.Any] | t.Sequence[tuple[str, t.Any]] | None
+    multipart: t.Any
+    form: t.Any
+    timeout: Duration | None
+    version: HttpVersionLike | None
 
 class HttpClient:
     def __init__(
@@ -24,47 +33,41 @@ class HttpClient:
         deflate: bool = True,
     ) -> None: ...
     async def get(
-        self, url: str | URL, *, headers: HeadersLike | None = None
+        self,
+        url: str | URL,
+        **kwargs: te.Unpack[RequestKwargs],
     ) -> Response: ...
     async def post(
         self,
         url: str | URL,
-        *,
-        body: Buffer | None = None,
-        headers: HeadersLike | None = None,
+        **kwargs: te.Unpack[RequestKwargs],
     ) -> Response: ...
     async def put(
         self,
         url: str | URL,
-        *,
-        body: Buffer | None = None,
-        headers: HeadersLike | None = None,
+        **kwargs: te.Unpack[RequestKwargs],
     ) -> Response: ...
     async def delete(
-        self, url: str | URL, *, headers: HeadersLike | None = None
+        self,
+        url: str | URL,
+        **kwargs: te.Unpack[RequestKwargs],
     ) -> Response: ...
     async def patch(
         self,
         url: str | URL,
-        *,
-        body: Buffer | None = None,
-        headers: dict[str, str] | None = None,
+        **kwargs: te.Unpack[RequestKwargs],
     ) -> Response: ...
     async def head(
-        self, url: str | URL, *, headers: HeadersLike | None = None
+        self,
+        url: str | URL,
+        **kwargs: te.Unpack[RequestKwargs],
     ) -> Response: ...
     async def fetch(
         self,
         url: str | URL,
         *,
         method: str = "GET",
-        body: Buffer | None = None,
-        headers: HeadersLike | None = None,
-        query: dict[str, t.Any] | t.Sequence[tuple[str, t.Any]] | None = None,
-        multipart: t.Any | None = None,  # TODO
-        form: t.Any | None = None,  # TODO
-        timeout: Duration | None = None,
-        version: HttpVersionLike | None = None,
+        **kwargs: te.Unpack[RequestKwargs],
     ) -> Response: ...
 
 class ReqwestError(Exception):
@@ -88,6 +91,7 @@ class Response:
     async def json(self) -> t.Any: ...
     async def bytes(self) -> ry.Bytes: ...
     def bytes_stream(self) -> ResponseStream: ...
+    def stream(self) -> ResponseStream: ...
     @property
     def url(self) -> URL: ...
     @property
@@ -116,11 +120,5 @@ async def fetch(
     *,
     client: HttpClient | None = None,
     method: str = "GET",
-    body: Buffer | None = None,
-    headers: HeadersLike | None = None,
-    query: dict[str, t.Any] | t.Sequence[tuple[str, t.Any]] | None = None,
-    multipart: t.Any = None,  # TODO
-    form: t.Any = None,  # TODO
-    timeout: Duration | None = None,
-    version: HttpVersionLike | None = None,
+    **kwargs: te.Unpack[RequestKwargs],
 ) -> Response: ...


### PR DESCRIPTION
- reqwest types fixed up to use typed-dict and `typing_extensions.unpack`
- jiff serde feat
___

# ai word salad

This pull request introduces several updates across dependencies, serialization support, and documentation. It upgrades multiple dependencies, adds optional `serde` support for serialization and deserialization in several structs, and enhances the documentation to improve clarity and usability. Below is a summary of the most important changes grouped by theme:

### Dependency Updates
* Upgraded multiple dependencies in `Cargo.toml`, including `anyhow` (1.0.75 → 1.0), `bzip2` (0.5.1 → 0.5.2), `globset` (0.4.15 → 0.4.16), `jiff` (0.2.13 → 0.2.14), and `zstd` (0.13.2 → 0.13.3). [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L157-R170) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L192-R192)

### Serialization Support
* Added optional `serde` support for serialization and deserialization in structs like `RyDate`, `RyDateTime`, `RySignedDuration`, `RySpan`, `RyTime`, `RyTimestamp`, and `RyZoned` by using `#[cfg_attr(feature = "serde", derive(...))]`. [[1]](diffhunk://#diff-685d25e264f13f8225a09dde7b6ccaefa9a3a25fd22ff56ee613ded4caa5805bL27-R30) [[2]](diffhunk://#diff-d09437bbc50fe18450ae2044b4b2031296d777d74b4cf02b5bbb86d6f3272fcaL22-R26) [[3]](diffhunk://#diff-113883407c4df9e66f96df5fc2917a75b3aa6a509530e9c57b117753410c9119L19-R21) [[4]](diffhunk://#diff-5324cbdb3caf79c4c699550bc00be83a95f73cbc2ad81d4113ca3391f4e50231R15-R28) [[5]](diffhunk://#diff-fceaaabdcdc06f7cec6118b3a40824ea588f60578b32d2bc7c4591ea861e8b34R19-R24) [[6]](diffhunk://#diff-023e42805787a2c8f06fc6dcbb955a50a59aeffefc8c1eb2e0e98b766d8fe886L21-R23) [[7]](diffhunk://#diff-d151d1588ad6ca674509b3ab7284cdaadfe9895e948fc38404bab4cc17e67e53L25-R27)

### Code Enhancements
* Made several methods `pub(crate)` to limit their visibility while maintaining flexibility for internal use, such as `at` in `RyDate` and `in_tz` in `RyDateTime`. [[1]](diffhunk://#diff-685d25e264f13f8225a09dde7b6ccaefa9a3a25fd22ff56ee613ded4caa5805bL66-R74) [[2]](diffhunk://#diff-d09437bbc50fe18450ae2044b4b2031296d777d74b4cf02b5bbb86d6f3272fcaL312-R315)
* Added a new `test` module with a unit test to verify serialization and deserialization of structs using `serde`.

### Documentation Improvements
* Refactored the `docs/src/api.md` to introduce `RequestKwargs` for cleaner and more concise method signatures in `HttpClient` and related classes. Added new methods like `stream()` to the `Response` class. [[1]](diffhunk://#diff-fddbb0c4374f39037dfe84277565868b29048f3c019a50e1db34c3b49b666a07L2541-R2558) [[2]](diffhunk://#diff-fddbb0c4374f39037dfe84277565868b29048f3c019a50e1db34c3b49b666a07L2566-R2610) [[3]](diffhunk://#diff-fddbb0c4374f39037dfe84277565868b29048f3c019a50e1db34c3b49b666a07R2636)
* Improved formatting and removed unnecessary blank lines in the documentation for better readability. [[1]](diffhunk://#diff-fddbb0c4374f39037dfe84277565868b29048f3c019a50e1db34c3b49b666a07L3376-L3434) [[2]](diffhunk://#diff-fddbb0c4374f39037dfe84277565868b29048f3c019a50e1db34c3b49b666a07L3443-L3447) [[3]](diffhunk://#diff-fddbb0c4374f39037dfe84277565868b29048f3c019a50e1db34c3b49b666a07L3458-L3459)