### PR TITLE
clippy serde fix for jiff and unsafe structs

### DIFF
--- a/crates/ryo3-jiff/src/lib.rs
+++ b/crates/ryo3-jiff/src/lib.rs
@@ -10,7 +10,6 @@
 #![deny(clippy::missing_panics_doc)]
 #![deny(clippy::arithmetic_side_effects)]
 #![expect(clippy::missing_errors_doc)]
-#![cfg_attr(feature = "serde", expect(clippy::unsafe_derive_deserialize))]
 extern crate core;
 
 pub mod pydatetime_conversions;

--- a/crates/ryo3-jiff/src/ry_date.rs
+++ b/crates/ryo3-jiff/src/ry_date.rs
@@ -24,10 +24,10 @@ use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::ops::Sub;
 
-#[pyclass(name = "Date", module = "ry.ryo3", frozen)]
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[pyclass(name = "Date", module = "ry.ryo3", frozen)]
 pub struct RyDate(pub(crate) Date);
 
 #[pymethods]

--- a/crates/ryo3-jiff/src/ry_datetime.rs
+++ b/crates/ryo3-jiff/src/ry_datetime.rs
@@ -21,7 +21,7 @@ use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::str::FromStr;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 #[pyclass(name = "DateTime", module = "ry.ryo3", frozen)]

--- a/crates/ryo3-jiff/src/ry_signed_duration.rs
+++ b/crates/ryo3-jiff/src/ry_signed_duration.rs
@@ -16,7 +16,7 @@ use std::str::FromStr;
 
 const NANOS_PER_SEC: i32 = 1_000_000_000;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[derive(Debug, Clone, PartialOrd, PartialEq)]
 #[pyclass(name = "SignedDuration", module = "ry.ryo3", frozen)]

--- a/crates/ryo3-jiff/src/ry_span.rs
+++ b/crates/ryo3-jiff/src/ry_span.rs
@@ -12,7 +12,7 @@ use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::str::FromStr;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[derive(Debug, Clone)]
 #[pyclass(name = "TimeSpan", module = "ry.ryo3", frozen)]

--- a/crates/ryo3-jiff/src/ry_time.rs
+++ b/crates/ryo3-jiff/src/ry_time.rs
@@ -18,7 +18,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::ops::Sub;
 use std::str::FromStr;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[pyclass(name = "Time", module = "ry.ryo3", frozen)]

--- a/crates/ryo3-jiff/src/ry_timestamp.rs
+++ b/crates/ryo3-jiff/src/ry_timestamp.rs
@@ -18,7 +18,7 @@ use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::str::FromStr;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 #[pyclass(name = "Timestamp", module = "ry.ryo3", frozen)]

--- a/crates/ryo3-jiff/src/ry_zoned.rs
+++ b/crates/ryo3-jiff/src/ry_zoned.rs
@@ -25,7 +25,7 @@ use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::str::FromStr;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[derive(Debug, Clone, PartialEq)]
 #[pyclass(name = "ZonedDateTime", module = "ry.ryo3", frozen)]

--- a/crates/ryo3-jiff/src/serde.rs
+++ b/crates/ryo3-jiff/src/serde.rs
@@ -1,4 +1,6 @@
-use crate::RyTimeZone;
+use crate::{
+    RyDate, RyDateTime, RySignedDuration, RySpan, RyTime, RyTimeZone, RyTimestamp, RyZoned,
+};
 use serde::Serialize;
 
 impl Serialize for RyTimeZone {
@@ -9,3 +11,27 @@ impl Serialize for RyTimeZone {
         jiff::fmt::serde::tz::required::serialize(&self.0, serializer)
     }
 }
+
+// implement the deserialize macro for a ry-jiff-wrapper type to avoid the
+// annoying clippy error messages
+macro_rules! impl_deserialize {
+    ($ry_type:ty, $jiff_type:ty) => {
+        impl<'de> serde::Deserialize<'de> for $ry_type {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let inner: $jiff_type = serde::Deserialize::deserialize(deserializer)?;
+                Ok(Self::from(inner))
+            }
+        }
+    };
+}
+
+impl_deserialize!(RyDate, jiff::civil::Date);
+impl_deserialize!(RyDateTime, jiff::civil::DateTime);
+impl_deserialize!(RySignedDuration, jiff::SignedDuration);
+impl_deserialize!(RySpan, jiff::Span);
+impl_deserialize!(RyTime, jiff::civil::Time);
+impl_deserialize!(RyTimestamp, jiff::Timestamp);
+impl_deserialize!(RyZoned, jiff::Zoned);


### PR DESCRIPTION
implement deserialize for each type in `ryo3-jiff` to not have to deal with:

`#![cfg_attr(feature = "serde", expect(clippy::unsafe_derive_deserialize))]`