### PR TITLE
Fix typos and bump version to 0.0.66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v0.0.66 [unreleased]
+
+- misc
+  - fix typos in python tests
+
+---
+
 ## v0.0.65 [2025-10-24]
 
 - `ryo3-reqwest`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.41"
+version = "1.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
+checksum = "81bbf3b3619004ad9bd139f62a9ab5cfe467f307455a0d307b0cf58bf070feaa"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
@@ -402,9 +402,9 @@ checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "flate2"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -977,8 +977,8 @@ dependencies = [
 
 [[package]]
 name = "jiter"
-version = "0.11.1"
-source = "git+https://github.com/jessekrubin/jiter.git?branch=pyo3-v0.27.x#d698d4f03cf69b1a01797695fd32e237e970e7fa"
+version = "0.12.0"
+source = "git+https://github.com/pydantic/jiter.git#f9f3217b722ba862a97c8c547b3775fae933afb6"
 dependencies = [
  "ahash",
  "bitvec",
@@ -1077,9 +1077,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litrs"
-version = "0.4.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1319,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -1716,7 +1716,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ry"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "jiff",
  "pyo3",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "jiff",
  "pyo3",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-brotli"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "brotli",
  "pyo3",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-bytes"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "ahash",
  "bytes",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-bzip2"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "bzip2",
  "pyo3",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-core"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-dev"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "serde",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-dirs"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "dirs",
  "pyo3",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-flate2"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "flate2",
  "pyo3",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-fnv"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "fnv",
  "pyo3",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-fspath"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-glob"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "glob",
  "parking_lot",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-globset"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "globset",
  "pyo3",
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-heck"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "heck",
  "pyo3",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-http"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "http",
  "parking_lot",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-ignore"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "ignore",
  "pyo3",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-jiff"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "jiff",
  "parking_lot",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-jiter"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "jiter",
  "pyo3",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-json"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "ryo3-bytes",
@@ -1944,14 +1944,14 @@ dependencies = [
 
 [[package]]
 name = "ryo3-macro-rules"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "ryo3-memchr"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "memchr",
  "pyo3",
@@ -1961,21 +1961,21 @@ dependencies = [
 
 [[package]]
 name = "ryo3-pydantic"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "ryo3-quick-maths"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "ryo3-regex"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "regex",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-reqwest"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "bytes",
  "cookie",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-same-file"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "ryo3-core",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-serde"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "jiff",
  "pyo3",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-shlex"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "shlex",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-size"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "size",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-sqlformat"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "sqlformat",
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-std"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "bytes",
  "jiff",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-tokio"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "futures",
  "pyo3",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-tokio-websockets"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "tokio-websockets",
@@ -2093,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-twox-hash"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "ryo3-bytes",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-ulid"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "ryo3-pydantic",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-unindent"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "unindent",
@@ -2123,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-url"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "ryo3-macro-rules",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-uuid"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-walkdir"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "parking_lot",
  "pyo3",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-which"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "ryo3-regex",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "ryo3-zstd"
-version = "0.0.65"
+version = "0.0.66"
 dependencies = [
  "pyo3",
  "ryo3-bytes",
@@ -2367,9 +2367,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.107"
+version = "2.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
+checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ inherits = "release"
 lto = "fat"
 
 [workspace.package]
-version = "0.0.65"
+version = "0.0.66"
 authors = [
   "jesse k. rubin <jessekrubin@gmail.com>",
   # hopefully you will contribute!
@@ -196,7 +196,7 @@ globset = { version = "0.4.17", features = ["serde"] }
 heck = "0.5.0"
 http = "1.3.1"
 jiff = { version = "0.2.14", features = ["default", "serde", "perf-inline"] }
-jiter = { version = "0.11.1", features = ["python"] }
+jiter = { version = "0.12", features = ["python"] }
 memchr = "2.7.5"
 parking_lot = "0.12.5"
 regex = "1.12.2"
@@ -278,4 +278,5 @@ use_self = "warn"
 [patch.crates-io]
 # pyo3 = { git = "https://github.com/pyo3/pyo3.git" }
 # pyo3-build-config = { git = "https://github.com/pyo3/pyo3.git" }
-jiter = { git = "https://github.com/jessekrubin/jiter.git", branch = "pyo3-v0.27.x" }
+# jiter = { git = "https://github.com/jessekrubin/jiter.git", branch = "pyo3-v0.27.x" }
+jiter = { git = "https://github.com/pydantic/jiter.git" }

--- a/tests/sqlformat/test_sqlfmt.py
+++ b/tests/sqlformat/test_sqlfmt.py
@@ -315,7 +315,7 @@ def st_sqlformat_options() -> st.SearchStrategy[_SqlFormatOptions]:
     )
 
 
-def _cannonicalize_options(options: _SqlFormatOptions) -> _SqlFormatOptions:
+def _canonicalize_options(options: _SqlFormatOptions) -> _SqlFormatOptions:
     """Convert options to their canonical form for comparison with SqlFormatter.to_dict() output."""
     canonical: _SqlFormatOptions = options.copy()
     if (
@@ -334,7 +334,7 @@ def test_sql_formatter_to_dict(options: _SqlFormatOptions) -> None:
     sf = ry.SqlFormatter(**options)
     d = sf.to_dict()
     assert isinstance(d, dict)
-    assert d == _cannonicalize_options(options)
+    assert d == _canonicalize_options(options)
     assert all(key in d for key in _SQL_FORMAT_DEFAULTS.keys())
 
 
@@ -351,40 +351,40 @@ def test_sql_formattter_repr_eval(options: _SqlFormatOptions) -> None:
     sf = ry.SqlFormatter(**options)
     repr_str = repr(sf)
 
-    cannonical_options = _cannonicalize_options(options)
+    canonical_options = _canonicalize_options(options)
     indent_kwargs = (
         "indent=-1"
-        if cannonical_options["indent"] == -1
-        else f"indent={cannonical_options['indent']}"
+        if canonical_options["indent"] == -1
+        else f"indent={canonical_options['indent']}"
     )
     ignore_case_convert_kwarg = (
-        f"ignore_case_convert={cannonical_options['ignore_case_convert']!r}, ".replace(
+        f"ignore_case_convert={canonical_options['ignore_case_convert']!r}, ".replace(
             "'", '"'
         )
-        if cannonical_options["ignore_case_convert"]
+        if canonical_options["ignore_case_convert"]
         else ""
     )
 
     expected_repr = "".join([
         "SqlFormatter(",
         indent_kwargs + ", ",
-        f"uppercase={cannonical_options['uppercase']}, ",
-        f"lines_between_queries={cannonical_options['lines_between_queries']}, ",
+        f"uppercase={canonical_options['uppercase']}, ",
+        f"lines_between_queries={canonical_options['lines_between_queries']}, ",
         ignore_case_convert_kwarg,
-        f"inline={cannonical_options['inline']}, ",
-        f"max_inline_block={cannonical_options['max_inline_block']}, ",
+        f"inline={canonical_options['inline']}, ",
+        f"max_inline_block={canonical_options['max_inline_block']}, ",
         (
-            f"max_inline_arguments={cannonical_options['max_inline_arguments']!r}, "
-            if cannonical_options["max_inline_arguments"] is not None
+            f"max_inline_arguments={canonical_options['max_inline_arguments']!r}, "
+            if canonical_options["max_inline_arguments"] is not None
             else ""
         ),
         (
-            f"max_inline_top_level={cannonical_options['max_inline_top_level']!r}, "
-            if cannonical_options["max_inline_top_level"] is not None
+            f"max_inline_top_level={canonical_options['max_inline_top_level']!r}, "
+            if canonical_options["max_inline_top_level"] is not None
             else ""
         ),
-        f"joins_as_top_level={cannonical_options['joins_as_top_level']}, ",
-        f'dialect="{cannonical_options["dialect"]}"',
+        f"joins_as_top_level={canonical_options['joins_as_top_level']}, ",
+        f'dialect="{canonical_options["dialect"]}"',
         ")",
     ])
     assert repr_str == expected_repr


### PR DESCRIPTION
Correct typos in Python tests and update the version number to 0.0.66. 

Fixed jiter to point to the main pydantic repo post https://github.com/pydantic/jiter/pull/228